### PR TITLE
Add gzip compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ values_production*
 
 
 values_staging.yaml
+
+.vs

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.org/proxy-pass-headers: directory_id
+    nginx.org/server-snippets: "gzip on;"
     {{ if eq .Values.useTls true}}
     cert-manager.io/issuer: "letsencrypt-prod"
     {{ end }}

--- a/templates/ingress_configmap.yaml
+++ b/templates/ingress_configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 data:
   enable-underscores-in-headers: "true"
   ignore-invalid-headers: "false"
+  use-gzip: "true" # ENABLE GZIP COMPRESSION
+  gzip-types: "*" # SPECIFY MIME TYPES TO COMPRESS ("*" FOR ALL) 
 metadata:
   name: nginx-configuration
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Context of being a 6x difference between the compressed and uncompressed CSS and JS

This is causing something like 80% of the load time according to chrome lighthouse

I think this is a regression perhaps app engine did this automatically

![image](https://user-images.githubusercontent.com/18080164/140015419-b4ccbda0-d1c4-4935-874b-e3f981310f60.png)


http://nginx.org/en/docs/http/ngx_http_gzip_module.html

https://stackoverflow.com/questions/54314250/gzip-in-gke-with-nginx-ingress

https://github.com/nginxinc/kubernetes-ingress/issues/179

Context that we were already doing this in webpack so just had to "turn it on" in helm/k8s/ingress etc
